### PR TITLE
Ignore assert deprecation errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,18 @@ module.exports = {
     "no-multi-spaces": "off",
     "comma-dangle": "off",
     "node/no-unpublished-require": "off",
-    "promise/always-return": "off"
+    "promise/always-return": "off",
+    "node/no-deprecated-api": [
+      "error",
+      {
+        // To ignore these errors, we need to omit support Node.js < 9.9.x
+        ignoreModuleItems: [
+          "assert.deepEqual",
+          "assert.equal",
+          "assert.notDeepEqual",
+          "assert.notEqual"
+        ]
+      }
+    ]
   }
 };


### PR DESCRIPTION
The new version of eslint-plugin-node published.

To merge https://github.com/Leko/wasm-instantiate-streaming/pull/13, we need to except these rules.
